### PR TITLE
[feature] Implement sharedPreference and preference datastore data sources

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -171,6 +171,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.datastore.preferences)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,6 +121,13 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.10"
     }
+    testOptions {
+        animationsDisabled = true
+
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
     packaging {
         resources {
             excludes.addAll(
@@ -172,7 +179,14 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.core.ktx)
     testImplementation(libs.junit)
+    testImplementation(libs.junit.vintage.engine)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.mockk)
+    testImplementation(libs.mockk.agent.jvm)
+    androidTestImplementation(libs.mockk.android)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 import java.io.FileInputStream
 import java.io.InputStreamReader

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/MainActivity.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/MainActivity.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
 package com.rwmobi.fuseduserpreferences
 
 import android.os.Bundle

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/AppPreferences.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/AppPreferences.kt
@@ -4,6 +4,7 @@
 
 package com.rwmobi.fuseduserpreferences.data.datasources
 
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 const val PREF_KEY_STRING = "keyString"
@@ -15,6 +16,7 @@ interface AppPreferences {
     val stringPreference: StateFlow<String>
     val booleanPreference: StateFlow<Boolean>
     val intPreference: StateFlow<Int>
+    val preferenceErrors: SharedFlow<Throwable> // For error reporting
 
     suspend fun updateStringPreference(newValue: String)
     suspend fun updateBooleanPreference(newValue: Boolean)

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/AppPreferences.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/AppPreferences.kt
@@ -10,7 +10,7 @@ const val PREF_KEY_STRING = "keyString"
 const val PREF_KEY_BOOLEAN = "keyBoolean"
 const val PREF_KEY_INT = "keyInt"
 
-interface Preferences {
+interface AppPreferences {
 
     val stringPreference: StateFlow<String>
     val booleanPreference: StateFlow<Boolean>

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/Preferences.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/Preferences.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
+package com.rwmobi.fuseduserpreferences.data.datasources
+
+import kotlinx.coroutines.flow.StateFlow
+
+const val PREF_KEY_STRING = "keyString"
+const val PREF_KEY_BOOLEAN = "keyBoolean"
+const val PREF_KEY_INT = "keyInt"
+
+interface Preferences {
+
+    val stringPreference: StateFlow<String>
+    val booleanPreference: StateFlow<Boolean>
+    val intPreference: StateFlow<Int>
+
+    suspend fun updateStringPreference(newValue: String)
+    suspend fun updateBooleanPreference(newValue: Boolean)
+    suspend fun updateIntPreference(newValue: Int)
+    suspend fun clear()
+}

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/prefdatastore/PreferenceDataStore.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/prefdatastore/PreferenceDataStore.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
+package com.rwmobi.fuseduserpreferences.data.datasources.prefdatastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.rwmobi.fuseduserpreferences.data.datasources.AppPreferences
+import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_BOOLEAN
+import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_INT
+import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_STRING
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+
+class PreferenceDataStore(val dataStore: DataStore<Preferences>, dispatcher: CoroutineDispatcher) : AppPreferences {
+    private val stringPreferenceDefault = ""
+    private val booleanPreferenceDefault = false
+    private val intPreferenceDefault = 0
+
+    private val _stringPreference = MutableStateFlow(stringPreferenceDefault)
+    override val stringPreference = _stringPreference.asStateFlow()
+
+    private val _booleanPreference = MutableStateFlow(booleanPreferenceDefault)
+    override val booleanPreference = _booleanPreference.asStateFlow()
+
+    private val _intPreference = MutableStateFlow(intPreferenceDefault)
+    override val intPreference = _intPreference.asStateFlow()
+
+    companion object {
+        val DATASTORE_PREF_KEY_STRING = stringPreferencesKey(PREF_KEY_STRING)
+        val DATASTORE_PREF_KEY_BOOLEAN = booleanPreferencesKey(PREF_KEY_BOOLEAN)
+        val DATASTORE_PREF_KEY_INT = intPreferencesKey(PREF_KEY_INT)
+    }
+
+    init {
+        CoroutineScope(dispatcher).launch {
+            dataStore.data.catch { exception ->
+                // Handle dataStore.data flow exceptions here
+                exception.printStackTrace()
+            }
+                .collect { prefs ->
+                    _stringPreference.value = prefs[DATASTORE_PREF_KEY_STRING] ?: stringPreferenceDefault
+                    _booleanPreference.value = prefs[DATASTORE_PREF_KEY_BOOLEAN] ?: booleanPreferenceDefault
+                    _intPreference.value = prefs[DATASTORE_PREF_KEY_INT] ?: intPreferenceDefault
+                }
+        }
+    }
+
+    override suspend fun updateStringPreference(newValue: String) {
+        dataStore.edit { mutablePreferences ->
+            mutablePreferences[DATASTORE_PREF_KEY_STRING] = newValue
+        }
+    }
+
+    override suspend fun updateBooleanPreference(newValue: Boolean) {
+        dataStore.edit { mutablePreferences ->
+            mutablePreferences[DATASTORE_PREF_KEY_BOOLEAN] = newValue
+        }
+    }
+
+    override suspend fun updateIntPreference(newValue: Int) {
+        dataStore.edit { mutablePreferences ->
+            mutablePreferences[DATASTORE_PREF_KEY_INT] = newValue
+        }
+    }
+
+    override suspend fun clear() {
+        dataStore.edit { mutablePreferences ->
+            mutablePreferences.clear()
+        }
+    }
+}

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/sharedprefs/SharedPreferenceWrapper.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/sharedprefs/SharedPreferenceWrapper.kt
@@ -9,59 +9,86 @@ import com.rwmobi.fuseduserpreferences.data.datasources.AppPreferences
 import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_BOOLEAN
 import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_INT
 import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_STRING
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class SharedPreferenceWrapper(private val sharedPreferences: SharedPreferences) : AppPreferences {
+class SharedPreferenceWrapper(
+    private val sharedPreferences: SharedPreferences,
+    private val stringPreferenceDefault: String = "",
+    private val booleanPreferenceDefault: Boolean = false,
+    private val intPreferenceDefault: Int = 0,
+) : AppPreferences {
 
-    private val _stringPreference = MutableStateFlow("")
+    private val _stringPreference = MutableStateFlow(stringPreferenceDefault)
     override val stringPreference = _stringPreference.asStateFlow()
 
-    private val _booleanPreference = MutableStateFlow(false)
+    private val _booleanPreference = MutableStateFlow(booleanPreferenceDefault)
     override val booleanPreference = _booleanPreference.asStateFlow()
 
-    private val _intPreference = MutableStateFlow(0)
+    private val _intPreference = MutableStateFlow(intPreferenceDefault)
     override val intPreference = _intPreference.asStateFlow()
+
+    // SharedPreferences operations do not typically throw exceptions in their standard use
+    private val _preferenceErrors = MutableSharedFlow<Throwable>()
+    override val preferenceErrors = _preferenceErrors.asSharedFlow()
 
     init {
         sharedPreferences.registerOnSharedPreferenceChangeListener { sharedPref, key ->
             when (key) {
                 PREF_KEY_STRING -> {
-                    _stringPreference.value = sharedPref.getString(PREF_KEY_STRING, null) ?: ""
+                    _stringPreference.value = sharedPref.getString(PREF_KEY_STRING, null) ?: stringPreferenceDefault
                 }
 
                 PREF_KEY_BOOLEAN -> {
-                    _booleanPreference.value = sharedPref.getBoolean(PREF_KEY_BOOLEAN, false)
+                    _booleanPreference.value = sharedPref.getBoolean(PREF_KEY_BOOLEAN, booleanPreferenceDefault)
                 }
 
                 PREF_KEY_INT -> {
-                    _intPreference.value = sharedPref.getInt(PREF_KEY_INT, 0)
+                    _intPreference.value = sharedPref.getInt(PREF_KEY_INT, intPreferenceDefault)
                 }
             }
         }
     }
 
     override suspend fun updateStringPreference(newValue: String) {
-        sharedPreferences.edit()
-            .putString(PREF_KEY_STRING, newValue)
-            .apply()
+        try {
+            sharedPreferences.edit()
+                .putString(PREF_KEY_STRING, newValue)
+                .apply()
+        } catch (e: Throwable) {
+            _preferenceErrors.emit(e)
+        }
     }
 
     override suspend fun updateBooleanPreference(newValue: Boolean) {
-        sharedPreferences.edit()
-            .putBoolean(PREF_KEY_BOOLEAN, newValue)
-            .apply()
+        try {
+            sharedPreferences.edit()
+                .putBoolean(PREF_KEY_BOOLEAN, newValue)
+                .apply()
+        } catch (e: Throwable) {
+            _preferenceErrors.emit(e)
+        }
     }
 
     override suspend fun updateIntPreference(newValue: Int) {
-        sharedPreferences.edit()
-            .putInt(PREF_KEY_INT, newValue)
-            .apply()
+        try {
+            sharedPreferences.edit()
+                .putInt(PREF_KEY_INT, newValue)
+                .apply()
+        } catch (e: Throwable) {
+            _preferenceErrors.emit(e)
+        }
     }
 
     override suspend fun clear() {
-        sharedPreferences.edit()
-            .clear()
-            .apply()
+        try {
+            sharedPreferences.edit()
+                .clear()
+                .apply()
+        } catch (e: Throwable) {
+            _preferenceErrors.emit(e)
+        }
     }
 }

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/sharedprefs/SharedPreferenceWrapper.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/sharedprefs/SharedPreferenceWrapper.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
+package com.rwmobi.fuseduserpreferences.data.datasources.sharedprefs
+
+import android.content.SharedPreferences
+import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_BOOLEAN
+import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_INT
+import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_STRING
+import com.rwmobi.fuseduserpreferences.data.datasources.Preferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class SharedPreferenceWrapper(private val sharedPreferences: SharedPreferences) : Preferences {
+
+    private val _stringPreference = MutableStateFlow("")
+    override val stringPreference = _stringPreference.asStateFlow()
+
+    private val _booleanPreference = MutableStateFlow(false)
+    override val booleanPreference = _booleanPreference.asStateFlow()
+
+    private val _intPreference = MutableStateFlow(0)
+    override val intPreference = _intPreference.asStateFlow()
+
+    init {
+        sharedPreferences.registerOnSharedPreferenceChangeListener { sharedPref, key ->
+            when (key) {
+                PREF_KEY_STRING -> {
+                    _stringPreference.value = sharedPref.getString(PREF_KEY_STRING, null) ?: ""
+                }
+
+                PREF_KEY_BOOLEAN -> {
+                    _booleanPreference.value = sharedPref.getBoolean(PREF_KEY_BOOLEAN, false)
+                }
+
+                PREF_KEY_INT -> {
+                    _intPreference.value = sharedPref.getInt(PREF_KEY_INT, 0)
+                }
+            }
+        }
+    }
+
+    override suspend fun updateStringPreference(newValue: String) {
+        sharedPreferences.edit()
+            .putString(PREF_KEY_STRING, newValue)
+            .apply()
+    }
+
+    override suspend fun updateBooleanPreference(newValue: Boolean) {
+        sharedPreferences.edit()
+            .putBoolean(PREF_KEY_BOOLEAN, newValue)
+            .apply()
+    }
+
+    override suspend fun updateIntPreference(newValue: Int) {
+        sharedPreferences.edit()
+            .putInt(PREF_KEY_INT, newValue)
+            .apply()
+    }
+
+    override suspend fun clear() {
+        sharedPreferences.edit()
+            .clear()
+            .apply()
+    }
+}

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/sharedprefs/SharedPreferenceWrapper.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/sharedprefs/SharedPreferenceWrapper.kt
@@ -5,14 +5,14 @@
 package com.rwmobi.fuseduserpreferences.data.datasources.sharedprefs
 
 import android.content.SharedPreferences
+import com.rwmobi.fuseduserpreferences.data.datasources.AppPreferences
 import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_BOOLEAN
 import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_INT
 import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_STRING
-import com.rwmobi.fuseduserpreferences.data.datasources.Preferences
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class SharedPreferenceWrapper(private val sharedPreferences: SharedPreferences) : Preferences {
+class SharedPreferenceWrapper(private val sharedPreferences: SharedPreferences) : AppPreferences {
 
     private val _stringPreference = MutableStateFlow("")
     override val stringPreference = _stringPreference.asStateFlow()

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/theme/Color.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/theme/Color.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
 package com.rwmobi.fuseduserpreferences.ui.theme
 
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/theme/Theme.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/theme/Theme.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
 package com.rwmobi.fuseduserpreferences.ui.theme
 
 import android.app.Activity

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/theme/Type.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/theme/Type.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
 package com.rwmobi.fuseduserpreferences.ui.theme
 
 import androidx.compose.material3.Typography

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,3 +1,7 @@
+<!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt"
     android:width="108dp"

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
 <resources>
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
+<!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
 <resources>
     <string name="app_name">Fused User Preferences</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
 <resources>
 
     <style name="Theme.FusedUserPreferences" parent="android:Theme.Material.Light.NoActionBar" />

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
+<!--
    Sample backup rules file; uncomment and customize as necessary.
    See https://developer.android.com/guide/topics/data/autobackup
    for details.

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+  -->
+
+<!--
    Sample data extraction rules file; uncomment and customize as necessary.
    See https://developer.android.com/about/versions/12/backup-restore#xml-changes
    for details.

--- a/app/src/test/kotlin/com/rwmobi/fuseduserpreferences/data/datasources/sharedprefs/SharedPreferenceWrapperTest.kt
+++ b/app/src/test/kotlin/com/rwmobi/fuseduserpreferences/data/datasources/sharedprefs/SharedPreferenceWrapperTest.kt
@@ -1,0 +1,76 @@
+package com.rwmobi.fuseduserpreferences.data.datasources.sharedprefs
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_BOOLEAN
+import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_INT
+import com.rwmobi.fuseduserpreferences.data.datasources.PREF_KEY_STRING
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class SharedPreferenceWrapperTest {
+
+    private lateinit var sharedPreferenceWrapper: SharedPreferenceWrapper
+    private lateinit var sharedPreferences: SharedPreferences
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        sharedPreferences = context.getSharedPreferences("test_prefs", Context.MODE_PRIVATE)
+        sharedPreferenceWrapper = SharedPreferenceWrapper(sharedPreferences)
+    }
+
+    @Test
+    fun `verify string preference update`() = runTest {
+        val newValue = "newString"
+        sharedPreferenceWrapper.updateStringPreference(newValue)
+
+        assertEquals(newValue, sharedPreferences.getString(PREF_KEY_STRING, null))
+    }
+
+    @Test
+    fun `verify boolean preference update`() = runTest {
+        val newValue = true
+        sharedPreferenceWrapper.updateBooleanPreference(newValue)
+
+        assertEquals(newValue, sharedPreferences.getBoolean(PREF_KEY_BOOLEAN, false))
+    }
+
+    @Test
+    fun `verify int preference update`() = runTest {
+        val newValue = 42
+        sharedPreferenceWrapper.updateIntPreference(newValue)
+
+        assertEquals(newValue, sharedPreferences.getInt(PREF_KEY_INT, 0))
+    }
+
+    @Test
+    fun `verify preferences are cleared`() = runTest {
+        // Setup initial values
+        with(sharedPreferences.edit()) {
+            putString(PREF_KEY_STRING, "string")
+            putBoolean(PREF_KEY_BOOLEAN, true)
+            putInt(PREF_KEY_INT, 1)
+            commit()
+        }
+
+        // Clear preferences
+        sharedPreferenceWrapper.clear()
+
+        with(sharedPreferences) {
+            assertEquals("", getString(PREF_KEY_STRING, ""))
+            assertEquals(false, getBoolean(PREF_KEY_BOOLEAN, false))
+            assertEquals(0, getInt(PREF_KEY_INT, 0))
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.androidApplication) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+#
+# Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+#
+
 # Project-wide Gradle settings.
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.3.0"
-kotlin = "1.9.23"
+kotlin = "1.9.22"
 coreKtx = "1.12.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,15 +4,20 @@ kotlin = "1.9.22"
 coreKtx = "1.12.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
+junitVintageEngine = "5.10.2"
 espressoCore = "3.5.1"
+kotlinxCoroutinesTest = "1.8.0"
 lifecycleRuntimeKtx = "2.7.0"
 activityCompose = "1.8.2"
 composeBom = "2024.02.02"
 ktlint = "12.1.0"
 datastorePreferences = "1.0.0"
+mockk = "1.13.10"
+coreKtxVersion = "1.5.0"
 
 # App configurations, not dependencies
 minsdk = "26"
+robolectric = "4.11.1"
 targetsdk = "34"
 compilesdk = "34"
 
@@ -31,8 +36,14 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-ktlint-gradle = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junitVintageEngine" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+mockk-agent-jvm = { group = "io.mockk", name = "mockk-agent-jvm", version.ref = "mockk" }
+mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "coreKtxVersion" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ lifecycleRuntimeKtx = "2.7.0"
 activityCompose = "1.8.2"
 composeBom = "2024.02.02"
 ktlint = "12.1.0"
+datastorePreferences = "1.0.0"
 
 # App configurations, not dependencies
 minsdk = "26"
@@ -31,6 +32,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 ktlint-gradle = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,7 @@
+#
+# Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+#
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024. Ryan Wong (hello@ryanwebmail.com)
+ */
+
 pluginManagement {
     repositories {
         google {


### PR DESCRIPTION
The data sources sharing the same interfaces so that we can use dependency inversion to choose which to use at the repository layer.

unit test for sharedpreference is done using Robolectric. 
unit test for datastore is pending