### PR TITLE
PreferencesDataStoreWrapper: combine update methods into one

### DIFF
--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/preferences/PreferencesDataStoreWrapper.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/data/datasources/preferences/PreferencesDataStoreWrapper.kt
@@ -23,31 +23,7 @@ class PreferencesDataStoreWrapper(
 
     fun getDataStoreFlow(): Flow<Preferences> = dataStore.data
 
-    suspend fun updateStringPreference(key: Preferences.Key<String>, newValue: String) {
-        withContext(dispatcher) {
-            try {
-                dataStore.edit { mutablePreferences ->
-                    mutablePreferences[key] = newValue
-                }
-            } catch (e: Throwable) {
-                _preferenceErrors.emit(e)
-            }
-        }
-    }
-
-    suspend fun updateBooleanPreference(key: Preferences.Key<Boolean>, newValue: Boolean) {
-        withContext(dispatcher) {
-            try {
-                dataStore.edit { mutablePreferences ->
-                    mutablePreferences[key] = newValue
-                }
-            } catch (e: Throwable) {
-                _preferenceErrors.emit(e)
-            }
-        }
-    }
-
-    suspend fun updateIntPreference(key: Preferences.Key<Int>, newValue: Int) {
+    suspend fun <T> updatePreference(key: Preferences.Key<T>, newValue: T) {
         withContext(dispatcher) {
             try {
                 dataStore.edit { mutablePreferences ->

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/data/repositories/PreferencesDataStoreRepository.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/data/repositories/PreferencesDataStoreRepository.kt
@@ -62,15 +62,15 @@ class PreferencesDataStoreRepository(
     }
 
     override suspend fun updateStringPreference(newValue: String) {
-        preferenceDataStoreWrapper.updateStringPreference(key = prefKeyString, newValue = newValue)
+        preferenceDataStoreWrapper.updatePreference(key = prefKeyString, newValue = newValue)
     }
 
     override suspend fun updateBooleanPreference(newValue: Boolean) {
-        preferenceDataStoreWrapper.updateBooleanPreference(key = prefKeyBoolean, newValue = newValue)
+        preferenceDataStoreWrapper.updatePreference(key = prefKeyBoolean, newValue = newValue)
     }
 
     override suspend fun updateIntPreference(newValue: Int) {
-        preferenceDataStoreWrapper.updateIntPreference(key = prefKeyInt, newValue = newValue)
+        preferenceDataStoreWrapper.updatePreference(key = prefKeyInt, newValue = newValue)
     }
 
     override suspend fun clear() {

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/BottomNavItem.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/BottomNavItem.kt
@@ -4,10 +4,10 @@
 
 package com.rwmobi.fuseduserpreferences.ui
 
-sealed class BottomNavItem(var title: String, var screen_route: String) {
+sealed class BottomNavItem(var title: String, var screenRoute: String) {
 
-    object SharedPreferences : BottomNavItem("SharedPreferences", "sharedPreferences")
-    object PreferencesDataStore : BottomNavItem("PreferencesDataStore", "preferencesDataStore")
+    data object SharedPreferences : BottomNavItem("SharedPreferences", "sharedPreferences")
+    data object PreferencesDataStore : BottomNavItem("PreferencesDataStore", "preferencesDataStore")
 
     companion object {
         val allItems: List<BottomNavItem>

--- a/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/components/BottomNavigationBar.kt
+++ b/app/src/main/java/com/rwmobi/fuseduserpreferences/ui/components/BottomNavigationBar.kt
@@ -21,9 +21,9 @@ fun BottomNavigationBar(navController: NavController) {
 
         for (item in BottomNavItem.allItems) {
             NavigationBarItem(
-                selected = currentRoute == item.screen_route,
+                selected = currentRoute == item.screenRoute,
                 onClick = {
-                    navController.navigate(item.screen_route) {
+                    navController.navigate(item.screenRoute) {
                         popUpTo(navController.graph.startDestinationId)
                         launchSingleTop = true
                     }

--- a/app/src/test/kotlin/com/rwmobi/fuseduserpreferences/data/datasources/preferences/PreferencesDataStoreWrapperTest.kt
+++ b/app/src/test/kotlin/com/rwmobi/fuseduserpreferences/data/datasources/preferences/PreferencesDataStoreWrapperTest.kt
@@ -56,7 +56,7 @@ class PreferencesDataStoreWrapperTest {
         val dataFlow = preferencesDataStoreWrapper.getDataStoreFlow()
 
         // Update the preference and wait for the flow to collect the new value.
-        preferencesDataStoreWrapper.updateStringPreference(key = prefKeyString, newValue = newValue)
+        preferencesDataStoreWrapper.updatePreference(key = prefKeyString, newValue = newValue)
 
         val flowJob = launch {
             dataFlow.collect { preferences ->
@@ -74,7 +74,7 @@ class PreferencesDataStoreWrapperTest {
         val newValue = true
         val dataFlow = preferencesDataStoreWrapper.getDataStoreFlow()
 
-        preferencesDataStoreWrapper.updateBooleanPreference(key = prefKeyBoolean, newValue = newValue)
+        preferencesDataStoreWrapper.updatePreference(key = prefKeyBoolean, newValue = newValue)
 
         val flowJob = launch {
             dataFlow.collect { preferences ->
@@ -92,7 +92,7 @@ class PreferencesDataStoreWrapperTest {
         val newValue = 42
         val dataFlow = preferencesDataStoreWrapper.getDataStoreFlow()
 
-        preferencesDataStoreWrapper.updateIntPreference(key = prefKeyInt, newValue = newValue)
+        preferencesDataStoreWrapper.updatePreference(key = prefKeyInt, newValue = newValue)
 
         val flowJob = launch {
             dataFlow.collect { preferences ->
@@ -109,9 +109,9 @@ class PreferencesDataStoreWrapperTest {
     fun testClear() = runTest {
         // Setup initial values
         with(preferencesDataStoreWrapper) {
-            updateStringPreference(key = prefKeyString, newValue = "newString")
-            updateBooleanPreference(key = prefKeyBoolean, newValue = true)
-            updateIntPreference(key = prefKeyInt, newValue = 42)
+            updatePreference(key = prefKeyString, newValue = "newString")
+            updatePreference(key = prefKeyBoolean, newValue = true)
+            updatePreference(key = prefKeyInt, newValue = 42)
         }
 
         val dataFlow = preferencesDataStoreWrapper.getDataStoreFlow()


### PR DESCRIPTION
Instead of creating multiple update methods, we can simply group them into one.
The repository is still opening separate method calls, so as to encapsulate the preference keys within it, and not managed by the viewmodel.